### PR TITLE
Feat/separate pipelines

### DIFF
--- a/.github/workflows/pipeline-all.yml
+++ b/.github/workflows/pipeline-all.yml
@@ -66,7 +66,7 @@ on:
         default: false
 
 concurrency:
-  group: pipeline-all
+  group: news-pipeline
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/pipeline-all.yml
+++ b/.github/workflows/pipeline-all.yml
@@ -1,0 +1,220 @@
+name: pipeline-all
+run-name: "pipeline-all @ ${{ github.ref_name }}"
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+    inputs:
+      pipeline_source:
+        description: "Which sources to ingest"
+        required: false
+        type: choice
+        default: "all"
+        options:
+          - all
+          - openai-only
+          - non-openai
+          - microsoft-ai-blog
+          - google-ai-blog
+          - google-deepmind-blog
+          - openai-blog
+          - apple-machine-learning
+          - simon-willison
+          - cursor-blog
+          - cursor-changelog
+          - matt-wolfe
+          - fireship
+          - ai-explained
+          - hugging-face
+      enable_backfill:
+        description: "Run enriched backfill for existing items"
+        required: false
+        default: false
+        type: boolean
+      backfill_all:
+        description: "When backfill is enabled, process all items"
+        required: false
+        default: false
+        type: boolean
+      backfill_method:
+        description: "Force specific extraction method"
+        required: false
+        type: choice
+        default: "default"
+        options:
+          - default
+          - youtube
+          - trafilatura
+          - markdown_new
+          - jina
+          - defuddle
+      skip_fetch:
+        description: "Skip fetch stage"
+        required: false
+        type: boolean
+        default: false
+      skip_enrich:
+        description: "Skip enrich stage"
+        required: false
+        type: boolean
+        default: false
+      skip_classify:
+        description: "Skip classify stage"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: pipeline-all
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  fetch:
+    if: ${{ !inputs.skip_fetch }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --all-groups
+
+      - name: Run fetch pipeline
+        id: fetch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          LOG_LEVEL: "INFO"
+          PIPELINE_SOURCE_ID: >-
+            ${{
+              inputs.pipeline_source != 'all'
+              && inputs.pipeline_source != 'openai-only'
+              && inputs.pipeline_source != 'non-openai'
+              && inputs.pipeline_source
+              || ''
+            }}
+          PIPELINE_EXCLUDE_SOURCE: >-
+            ${{
+              inputs.pipeline_source == 'non-openai'
+              && 'openai-blog'
+              || ''
+            }}
+        run: |
+          if [ "${{ inputs.pipeline_source }}" = "openai-only" ]; then
+            export PIPELINE_SOURCE_ID="openai-blog"
+          fi
+          uv run python -m app.jobs.fetch_pipeline
+
+      - name: Commit fetch data
+        if: always()
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/news.db data/status
+          if git diff --cached --quiet; then
+            echo "No data changes to commit."
+          else
+            git pull --rebase || echo "Rebase had conflicts"
+            git commit -m "chore(data): save fetch stage"
+            git push
+          fi
+
+  enrich:
+    needs: fetch
+    if: ${{ !inputs.skip_enrich && (inputs.pipeline_source != '' || github.event_name != 'workflow_dispatch') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --all-groups
+
+      - name: Install defuddle CLI
+        run: npm install -g defuddle@0.13.0
+        env:
+          DEFUDDLE_ENABLED: "1"
+
+      - name: Run enrich pipeline
+        id: enrich
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          DEFUDDLE_ENABLED: "1"
+          DEFUDDLE_TIMEOUT_SECONDS: "20"
+          DEFUDDLE_MAX_CHARS: "12000"
+          LOG_LEVEL: "INFO"
+        run: uv run python -m app.jobs.enrich_pipeline
+
+      - name: Commit enrich data
+        if: always()
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/news.db data/status
+          if git diff --cached --quiet; then
+            echo "No data changes to commit."
+          else
+            git pull --rebase || echo "Rebase had conflicts"
+            git commit -m "chore(data): save enrich stage"
+            git push
+          fi
+
+  classify:
+    needs: enrich
+    if: ${{ !inputs.skip_classify }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --all-groups
+
+      - name: Run classify pipeline
+        id: classify
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          LOG_LEVEL: "INFO"
+        run: uv run python -m app.jobs.classify_pipeline
+
+      - name: Commit classify data
+        if: always()
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/news.db data/status
+          if git diff --cached --quiet; then
+            echo "No data changes to commit."
+          else
+            git pull --rebase || echo "Rebase had conflicts"
+            git commit -m "chore(data): save classify stage"
+            git push
+          fi

--- a/.github/workflows/pipeline-classify.yml
+++ b/.github/workflows/pipeline-classify.yml
@@ -1,0 +1,53 @@
+name: pipeline-classify
+run-name: "classify @ ${{ github.ref_name }}"
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: pipeline-classify
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  classify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --all-groups
+
+      - name: Run classify pipeline
+        id: classify
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          LOG_LEVEL: "INFO"
+        run: uv run python -m app.jobs.classify_pipeline
+
+      - name: Commit and push data changes
+        if: always()
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/news.db data/status
+          
+          if git diff --cached --quiet; then
+            echo "No data changes to commit."
+          else
+            git pull --rebase || echo "Rebase had conflicts"
+            git commit -m "chore(data): save classify pipeline progress"
+            git push
+          fi

--- a/.github/workflows/pipeline-classify.yml
+++ b/.github/workflows/pipeline-classify.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: pipeline-classify
+  group: news-pipeline
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/pipeline-enrich.yml
+++ b/.github/workflows/pipeline-enrich.yml
@@ -41,7 +41,7 @@ on:
           - defuddle
 
 concurrency:
-  group: pipeline-enrich
+  group: news-pipeline
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/pipeline-enrich.yml
+++ b/.github/workflows/pipeline-enrich.yml
@@ -1,0 +1,125 @@
+name: pipeline-enrich
+run-name: "enrich @ ${{ github.ref_name }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_id:
+        description: "Filter to specific source"
+        required: false
+        type: string
+      exclude_source:
+        description: "Exclude source(s), comma-separated"
+        required: false
+        type: string
+      limit:
+        description: "Max articles to process"
+        required: false
+        type: number
+        default: 500
+      all:
+        description: "Process all matching articles (ignore limit)"
+        required: false
+        type: boolean
+        default: false
+      only_dirty:
+        description: "Only process likely dirty bodies"
+        required: false
+        type: boolean
+        default: false
+      method:
+        description: "Force specific extraction method"
+        required: false
+        type: choice
+        default: "default"
+        options:
+          - default
+          - youtube
+          - trafilatura
+          - markdown_new
+          - jina
+          - defuddle
+
+concurrency:
+  group: pipeline-enrich
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  enrich:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --all-groups
+
+      - name: Install defuddle CLI
+        run: npm install -g defuddle@0.13.0
+        env:
+          DEFUDDLE_ENABLED: "1"
+          DEFUDDLE_TIMEOUT_SECONDS: "20"
+          DEFUDDLE_MAX_CHARS: "12000"
+
+      - name: Run enrich pipeline
+        id: enrich
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          DEFUDDLE_ENABLED: "1"
+          DEFUDDLE_TIMEOUT_SECONDS: "20"
+          DEFUDDLE_MAX_CHARS: "12000"
+          LOG_LEVEL: "INFO"
+        run: |
+          CMD="uv run python -m app.jobs.enrich_pipeline"
+          
+          if [ -n "${{ inputs.source_id }}" ]; then
+            CMD="$CMD --source-id ${{ inputs.source_id }}"
+          fi
+          
+          if [ -n "${{ inputs.exclude_source }}" ]; then
+            CMD="$CMD --exclude-source ${{ inputs.exclude_source }}"
+          fi
+          
+          if [ "${{ inputs.all }}" = "true" ]; then
+            CMD="$CMD --all"
+          else
+            CMD="$CMD --limit ${{ inputs.limit }}"
+          fi
+          
+          if [ "${{ inputs.only_dirty }}" = "true" ]; then
+            CMD="$CMD --only-dirty"
+          fi
+          
+          if [ "${{ inputs.method }}" != "default" ]; then
+            CMD="$CMD --only-method ${{ inputs.method }}"
+          fi
+          
+          echo "Running: $CMD"
+          $CMD
+
+      - name: Commit and push data changes
+        if: always()
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/news.db data/status
+          
+          if git diff --cached --quiet; then
+            echo "No data changes to commit."
+          else
+            git pull --rebase || echo "Rebase had conflicts"
+            git commit -m "chore(data): save enrich pipeline progress"
+            git push
+          fi

--- a/.github/workflows/pipeline-fetch.yml
+++ b/.github/workflows/pipeline-fetch.yml
@@ -1,0 +1,93 @@
+name: pipeline-fetch
+run-name: "fetch @ ${{ github.ref_name }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      pipeline_source:
+        description: "Which sources to fetch"
+        required: false
+        type: choice
+        default: "all"
+        options:
+          - all
+          - openai-only
+          - non-openai
+          - microsoft-ai-blog
+          - google-ai-blog
+          - google-deepmind-blog
+          - openai-blog
+          - apple-machine-learning
+          - simon-willison
+          - cursor-blog
+          - cursor-changelog
+          - matt-wolfe
+          - fireship
+          - ai-explained
+          - hugging-face
+
+concurrency:
+  group: pipeline-fetch
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --all-groups
+
+      - name: Run fetch pipeline
+        id: fetch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          LOG_LEVEL: "INFO"
+          PIPELINE_SOURCE_ID: >-
+            ${{
+              inputs.pipeline_source != 'all'
+              && inputs.pipeline_source != 'openai-only'
+              && inputs.pipeline_source != 'non-openai'
+              && inputs.pipeline_source
+              || ''
+            }}
+          PIPELINE_EXCLUDE_SOURCE: >-
+            ${{
+              inputs.pipeline_source == 'non-openai'
+              && 'openai-blog'
+              || ''
+            }}
+        run: |
+          if [ "${{ inputs.pipeline_source }}" = "openai-only" ]; then
+            export PIPELINE_SOURCE_ID="openai-blog"
+          fi
+          uv run python -m app.jobs.fetch_pipeline
+
+      - name: Commit and push data changes
+        if: always()
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/news.db data/status
+          
+          if git diff --cached --quiet; then
+            echo "No data changes to commit."
+          else
+            git pull --rebase || echo "Rebase had conflicts"
+            git commit -m "chore(data): save fetch pipeline progress"
+            git push
+          fi

--- a/.github/workflows/pipeline-fetch.yml
+++ b/.github/workflows/pipeline-fetch.yml
@@ -27,7 +27,7 @@ on:
           - hugging-face
 
 concurrency:
-  group: pipeline-fetch
+  group: news-pipeline
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/pipeline-fetch.yml
+++ b/.github/workflows/pipeline-fetch.yml
@@ -25,6 +25,11 @@ on:
           - fireship
           - ai-explained
           - hugging-face
+      export:
+        description: "Export status files after fetch (enables feed dashboard)"
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: news-pipeline
@@ -75,7 +80,11 @@ jobs:
           if [ "${{ inputs.pipeline_source }}" = "openai-only" ]; then
             export PIPELINE_SOURCE_ID="openai-blog"
           fi
-          uv run python -m app.jobs.fetch_pipeline
+          if [ "${{ inputs.export }}" = "true" ]; then
+            uv run python -m app.jobs.fetch_pipeline --export
+          else
+            uv run python -m app.jobs.fetch_pipeline
+          fi
 
       - name: Commit and push data changes
         if: always()

--- a/app/jobs/classify_pipeline.py
+++ b/app/jobs/classify_pipeline.py
@@ -1,0 +1,183 @@
+"""Classify pipeline: cluster articles into events, categorize, and export status.
+
+This pipeline takes articles from the database and:
+1. Clusters similar articles into events (title similarity + simhash).
+2. Categorizes events using ML model or rule-based classifier.
+3. Exports all data to JSON files consumed by the dashboard.
+
+Triggered separately from fetch and enrich pipelines so that:
+- Classification/export runs independently of feed ingestion.
+- Event clustering can be tuned without affecting fetch or enrichment.
+- Export failures don't lose fetched content.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+import traceback
+import uuid
+from typing import Any
+
+from app.db import get_connection, init_db
+from app.incidents import GitHubIssueClient, IncidentSignal, sync_incident_open_or_update, sync_incident_resolve
+from app.jobs import stages_cluster, stages_export
+from app.jobs.pipeline import (
+    ARTICLES_EXPORT_LIMIT,
+    CLUSTER_LOOKBACK_DAYS,
+    CLUSTER_WINDOW_HOURS,
+    EVENTS_EXPORT_LIMIT,
+    EVENTS_WINDOW_HOURS,
+    SETTINGS,
+    SIMILARITY_THRESHOLD,
+    SLOW_SOURCE_LATENCY_MS,
+    SOURCE_CHECKS_HISTORY_LIMIT,
+    SOURCE_FAIL_THRESHOLD,
+    STALE_SOURCE_HOURS,
+    STATUS_DIR,
+    build_articles,
+    build_events,
+    build_incidents,
+    build_runs,
+    build_sources,
+    build_summary,
+    categorize_stage,
+    classify_event,
+    cluster_stage,
+    export_status,
+    extract_tags,
+    iso,
+    log_stage_summary,
+    pair_similarity,
+    parse_date,
+    sha1_hexdigest,
+    source_is_in_cooldown,
+    utc_now_iso,
+)
+from app.repos import run_repo
+
+logger = logging.getLogger("news.pipeline")
+
+
+def run_classify_pipeline() -> int:
+    conn = get_connection()
+    init_db(conn)
+
+    run_id = uuid.uuid4().hex[:12]
+    run_repo.create_pipeline_run(conn, run_id, utc_now_iso(), run_type="classify")
+    conn.commit()
+
+    issue_client = GitHubIssueClient()
+    pipeline_metrics: dict[str, Any] = {"run_id": run_id}
+    github_run_id = os.getenv("GITHUB_RUN_ID")
+    github_repo = os.getenv("GITHUB_REPOSITORY")
+    if github_run_id and github_repo:
+        pipeline_metrics["github_run_id"] = github_run_id
+        pipeline_metrics["github_run_url"] = (
+            f"https://github.com/{github_repo}/actions/runs/{github_run_id}"
+        )
+
+    stages = [
+        ("cluster", lambda: _run_cluster_stage(conn, run_id)),
+        ("categorize", lambda: _run_categorize_stage(conn, run_id)),
+        ("export", lambda: _run_export_stage(conn, run_id)),
+    ]
+
+    try:
+        for stage_name, stage_fn in stages:
+            logger.info("Classify stage started stage=%s run_id=%s", stage_name, run_id)
+            started = time.time()
+            result = stage_fn()
+            result["duration_ms"] = round((time.time() - started) * 1000, 2)
+            log_stage_summary(logger, stage_name=stage_name, status="success", metrics=result, run_id=run_id)
+            pipeline_metrics[stage_name] = result
+
+        run_repo.complete_pipeline_run(conn, run_id, utc_now_iso(), pipeline_metrics)
+        conn.commit()
+        logger.info("Classify pipeline succeeded run_id=%s", run_id)
+
+        sync_incident_resolve(
+            conn,
+            incident_key="pipeline:classify",
+            run_id=run_id,
+            resolution_message="Classify pipeline completed successfully.",
+            client=issue_client,
+        )
+        conn.commit()
+        return 0
+
+    except Exception as exc:
+        logger.exception("Classify pipeline failed run_id=%s error=%s", run_id, exc)
+        conn.rollback()
+        traceback_text = traceback.format_exc(limit=5)
+        run_repo.fail_pipeline_run(conn, run_id, utc_now_iso(), str(exc), pipeline_metrics)
+        conn.commit()
+        sync_incident_open_or_update(
+            conn,
+            IncidentSignal(
+                key="pipeline:classify",
+                kind="pipeline-stage",
+                target_id="classify",
+                message=f"Classify pipeline failed in run {run_id}: {exc}\n\n{traceback_text}",
+                severity="sev2",
+            ),
+            run_id=run_id,
+            client=issue_client,
+        )
+        conn.commit()
+        return 1
+
+
+def _run_stage(conn, run_id: str, stage_name: str, stage_fn) -> dict[str, Any]:
+    started_at = utc_now_iso()
+    stage_run_id = run_repo.create_stage_run(conn, run_id, stage_name, started_at)
+    conn.commit()
+    started = time.time()
+    try:
+        result = stage_fn()
+        result["duration_ms"] = round((time.time() - started) * 1000, 2)
+        run_repo.complete_stage_run(conn, stage_run_id, utc_now_iso(), "success", result)
+        conn.commit()
+        return result
+    except Exception:
+        run_repo.complete_stage_run(conn, stage_run_id, utc_now_iso(), "failed", {})
+        conn.commit()
+        raise
+
+
+def _run_cluster_stage(conn, run_id: str) -> dict[str, Any]:
+    return _run_stage(conn, run_id, "cluster", lambda: stages_cluster.cluster_stage(
+        conn,
+        parse_date=parse_date,
+        iso=iso,
+        pair_similarity=pair_similarity,
+        sha1_hexdigest=sha1_hexdigest,
+        similarity_threshold=SIMILARITY_THRESHOLD,
+        cluster_window_hours=CLUSTER_WINDOW_HOURS,
+        cluster_lookback_days=CLUSTER_LOOKBACK_DAYS,
+    ))
+
+
+def _run_categorize_stage(conn, run_id: str) -> dict[str, Any]:
+    return _run_stage(conn, run_id, "categorize", lambda: stages_cluster.categorize_stage(
+        conn,
+        classify_event=classify_event,
+    ))
+
+
+def _run_export_stage(conn, run_id: str) -> dict[str, Any]:
+    return _run_stage(conn, run_id, "export", lambda: stages_export.export_status(
+        conn,
+        status_dir=STATUS_DIR,
+        build_summary_fn=lambda c: build_summary(c),
+        build_sources_fn=lambda c: build_sources(c),
+        build_runs_fn=lambda c: build_runs(c),
+        build_incidents_fn=lambda c: build_incidents(c),
+        build_events_fn=lambda c: build_events(c),
+        build_articles_fn=lambda c: build_articles(c),
+    ))
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_classify_pipeline())

--- a/app/jobs/enrich_pipeline.py
+++ b/app/jobs/enrich_pipeline.py
@@ -23,10 +23,17 @@ from typing import Any
 
 from app.db import get_connection, init_db
 from app.incidents import GitHubIssueClient, IncidentSignal, sync_incident_open_or_update
-from app.jobs import pipeline
+from app.jobs import pipeline, stages_export
 from app.jobs.pipeline import (
     DEFUDDLE_ENABLED,
     SETTINGS,
+    STATUS_DIR,
+    build_articles,
+    build_events,
+    build_incidents,
+    build_runs,
+    build_sources,
+    build_summary,
     log_stage_summary,
     reset_markdown_new_circuit_breaker,
     utc_now_iso,
@@ -70,6 +77,7 @@ def run_enrich_pipeline(
     only_method: str | None = None,
     source_id: str | None = None,
     exclude_source: str | None = None,
+    export: bool = False,
 ) -> int:
     reset_markdown_new_circuit_breaker()
     conn = get_connection()
@@ -112,6 +120,24 @@ def run_enrich_pipeline(
 
         log_stage_summary(logger, stage_name="enrich", status="success", metrics=metrics, run_id=run_id)
         logger.info("Enrich pipeline succeeded run_id=%s enriched=%d", run_id, metrics.get("updated", 0))
+
+        if export:
+            logger.info("Running lightweight export for feed dashboard")
+            export_metrics = stages_export.export_status(
+                conn,
+                status_dir=STATUS_DIR,
+                build_summary_fn=lambda c: build_summary(c),
+                build_sources_fn=lambda c: build_sources(c),
+                build_runs_fn=lambda c: build_runs(c),
+                build_incidents_fn=lambda c: build_incidents(c),
+                build_events_fn=lambda c: build_events(c),
+                build_articles_fn=lambda c: build_articles(c),
+            )
+            logger.info("Export completed: %s", export_metrics)
+            pipeline_metrics["export"] = export_metrics
+            run_repo.complete_pipeline_run(conn, run_id, utc_now_iso(), pipeline_metrics)
+            conn.commit()
+
         return 0
 
     except Exception as exc:
@@ -313,6 +339,12 @@ def main() -> int:
     parser.add_argument("--only-method", type=str, choices=["youtube", "trafilatura", "markdown_new", "compress_new", "jina", "defuddle"], default=None, help="Force specific extraction method only")
     parser.add_argument("--source-id", type=str, default=None, help="Filter to a specific source")
     parser.add_argument("--exclude-source", type=str, default=None, help="Exclude source(s), comma-separated")
+    parser.add_argument(
+        "--export",
+        action="store_true",
+        default=False,
+        help="Export status files after enrichment (enables feed dashboard without classify pipeline)",
+    )
     args = parser.parse_args()
 
     return run_enrich_pipeline(
@@ -324,6 +356,7 @@ def main() -> int:
         only_method=args.only_method,
         source_id=args.source_id,
         exclude_source=args.exclude_source,
+        export=args.export,
     )
 
 

--- a/app/jobs/enrich_pipeline.py
+++ b/app/jobs/enrich_pipeline.py
@@ -1,0 +1,331 @@
+"""Enrichment pipeline: enrich articles that only have RSS body content.
+
+This pipeline queries articles that have not yet been enriched
+(extraction_method = 'rss' or body is short/empty) and applies the
+priority chain of content extraction methods (trafilatura, jina.ai,
+defuddle, markdown.new, etc.).
+
+Triggered separately from fetch and classify pipelines so that:
+- Enrichment can be tuned independently (timeouts, rate limits, budgets).
+- Enrichment failures do not block feed ingestion.
+- The pipeline can be re-run selectively on articles that need it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import time
+import traceback
+import uuid
+from typing import Any
+
+from app.db import get_connection, init_db
+from app.incidents import GitHubIssueClient, IncidentSignal, sync_incident_open_or_update
+from app.jobs import pipeline
+from app.jobs.pipeline import (
+    DEFUDDLE_ENABLED,
+    SETTINGS,
+    log_stage_summary,
+    reset_markdown_new_circuit_breaker,
+    utc_now_iso,
+)
+from app.models import ExtractionMethod
+from app.repos import article_repo, run_repo
+from app.settings import get_settings
+from app.utils import normalize_text, sha1_hexdigest, simhash64
+
+logger = logging.getLogger("news.pipeline")
+
+
+def _enrich_with_rate_limit(
+    url: str,
+    source_id: str,
+    title: str,
+    body: str,
+    max_markdown_new: int,
+    markdown_new_used: int,
+    only_method: str | None = None,
+) -> tuple[str, str, int]:
+    budget_remaining = max_markdown_new - markdown_new_used
+    enriched_body, method, rate_limit_remaining, _rate_limited = pipeline.enrich_with_policy(
+        url,
+        source_id,
+        title,
+        body,
+        only_method=only_method,
+        markdown_new_budget_remaining=budget_remaining,
+        stop_on_markdown_rate_limit=True,
+    )
+    return enriched_body, method, rate_limit_remaining
+
+
+def run_enrich_pipeline(
+    limit: int | None = None,
+    only_missing: bool = True,
+    only_dirty: bool = False,
+    skip_enriched: bool = True,
+    max_markdown_new: int = 100,
+    only_method: str | None = None,
+    source_id: str | None = None,
+    exclude_source: str | None = None,
+) -> int:
+    reset_markdown_new_circuit_breaker()
+    conn = get_connection()
+    init_db(conn)
+
+    run_id = uuid.uuid4().hex[:12]
+    run_repo.create_pipeline_run(conn, run_id, utc_now_iso(), run_type="enrich")
+    conn.commit()
+
+    pipeline_metrics: dict[str, Any] = {"run_id": run_id}
+    github_run_id = os.getenv("GITHUB_RUN_ID")
+    github_repo = os.getenv("GITHUB_REPOSITORY")
+    if github_run_id and github_repo:
+        pipeline_metrics["github_run_id"] = github_run_id
+        pipeline_metrics["github_run_url"] = (
+            f"https://github.com/{github_repo}/actions/runs/{github_run_id}"
+        )
+
+    stage_run_id = _create_stage_run(conn, run_id, "enrich")
+    started = time.time()
+    try:
+        metrics = _enrich_articles(
+            conn,
+            run_id,
+            limit=limit,
+            only_missing=only_missing,
+            only_dirty=only_dirty,
+            skip_enriched=skip_enriched,
+            max_markdown_new=max_markdown_new,
+            only_method=only_method,
+            source_id=source_id,
+            exclude_source=exclude_source,
+        )
+        metrics["duration_ms"] = round((time.time() - started) * 1000, 2)
+        _complete_stage_run(conn, stage_run_id, "success", metrics)
+
+        pipeline_metrics["enrich"] = metrics
+        run_repo.complete_pipeline_run(conn, run_id, utc_now_iso(), pipeline_metrics)
+        conn.commit()
+
+        log_stage_summary(logger, stage_name="enrich", status="success", metrics=metrics, run_id=run_id)
+        logger.info("Enrich pipeline succeeded run_id=%s enriched=%d", run_id, metrics.get("updated", 0))
+        return 0
+
+    except Exception as exc:
+        logger.exception("Enrich pipeline failed run_id=%s error=%s", run_id, exc)
+        conn.rollback()
+        traceback_text = traceback.format_exc(limit=5)
+        run_repo.fail_pipeline_run(conn, run_id, utc_now_iso(), str(exc), pipeline_metrics)
+        conn.commit()
+        return 1
+
+
+def _enrich_articles(
+    conn,
+    run_id: str,
+    limit: int | None = 500,
+    only_missing: bool = True,
+    only_dirty: bool = False,
+    skip_enriched: bool = True,
+    max_markdown_new: int = 100,
+    only_method: str | None = None,
+    source_id: str | None = None,
+    exclude_source: str | None = None,
+) -> dict[str, Any]:
+    where_missing = "AND (a.body IS NULL OR TRIM(a.body) = '' OR LENGTH(a.body) < 120)" if only_missing else ""
+    where_skip_enriched = "AND (a.extraction_method IS NULL OR a.extraction_method = 'rss')" if skip_enriched else ""
+    where_source = "AND a.source_id = ?" if source_id else ""
+    exclude_ids = [s.strip() for s in (exclude_source or "").split(",") if s.strip()]
+    where_exclude = ""
+    if exclude_ids:
+        placeholders = ",".join("?" for _ in exclude_ids)
+        where_exclude = f"AND a.source_id NOT IN ({placeholders})"
+    limit_clause = "" if limit is None else "LIMIT ?"
+    query = f"""
+        SELECT a.article_id, a.url, a.title, a.body, a.source_id, a.extraction_method
+        FROM articles a
+        WHERE TRIM(a.url) != ''
+        {where_missing}
+        {where_skip_enriched}
+        {where_source}
+        {where_exclude}
+        ORDER BY a.published_at DESC
+        {limit_clause}
+    """
+    params_list: list[str | int] = []
+    if source_id:
+        params_list.append(source_id)
+    params_list.extend(exclude_ids)
+    if limit is not None:
+        params_list.append(max(1, limit))
+    params = tuple(params_list) if params_list else ()
+    rows = conn.execute(query, params).fetchall()
+
+    if only_dirty:
+        rows = [r for r in rows if pipeline.is_probably_dirty_body(str(r["body"] or ""))]
+
+    total_rows = len(rows)
+    logger.info(
+        "Enrich pipeline candidates=%d only_missing=%s only_dirty=%s skip_enriched=%s max_markdown_new=%d only_method=%s source_id=%s",
+        total_rows, only_missing, only_dirty, skip_enriched, max_markdown_new, only_method, source_id,
+    )
+
+    attempted = 0
+    enriched = 0
+    updated = 0
+    unchanged = 0
+    misses = 0
+    markdown_new_used = 0
+    markdown_new_rate_limited = False
+    stopped_early = False
+    method_counts: dict[str, int] = {}
+    updates: list[tuple[str, str, str, str, str, int]] = []
+
+    progress_interval = max(1, total_rows // 10) if total_rows else 1
+    for row in rows:
+        attempted += 1
+        url = str(row["url"] or "")
+        sid = str(row["source_id"] or "")
+        title = str(row["title"] or "")
+        body = str(row["body"] or "")
+
+        current_method = str(row["extraction_method"] or "rss")
+        if skip_enriched and current_method != ExtractionMethod.RSS.value:
+            unchanged += 1
+            continue
+
+        if markdown_new_rate_limited and only_method == "markdown_new":
+            stopped_early = True
+            logger.warning(
+                "Stopping early due to markdown.new rate limit attempted=%d total=%d",
+                attempted - 1, total_rows,
+            )
+            break
+
+        new_body, method, rate_limit_remaining = _enrich_with_rate_limit(
+            url, sid, title, body, max_markdown_new, markdown_new_used, only_method,
+        )
+
+        if rate_limit_remaining == 0:
+            markdown_new_rate_limited = True
+            logger.warning("markdown.new rate limit hit, stopping further markdown.new attempts")
+
+        if method == ExtractionMethod.MARKDOWN_NEW.value:
+            markdown_new_used += 1
+
+        method_counts[method] = method_counts.get(method, 0) + 1
+
+        if method != ExtractionMethod.RSS.value and new_body:
+            enriched += 1
+        elif not new_body:
+            misses += 1
+
+        new_body = pipeline.truncate_for_storage(str(new_body or "").strip())
+        old_body = str(row["body"] or "").strip()
+        if not new_body or new_body == old_body:
+            unchanged += 1
+        else:
+            body_norm = normalize_text(new_body)
+            body_hash = sha1_hexdigest(body_norm)
+            title_norm = normalize_text(str(row["title"] or ""))
+            sh = str(simhash64(body_norm or title_norm))
+            updates.append((new_body, body_norm, body_hash, sh, method, int(row["article_id"])))
+
+        # Record enrichment attempt
+        enrichment_status = "success" if method != ExtractionMethod.RSS.value and new_body else "failed"
+        attempt_ts = utc_now_iso()
+        article_repo.record_enrichment_attempt(
+            conn,
+            article_url=url,
+            source_id=sid,
+            method=method,
+            status=enrichment_status,
+            duration_ms=None,
+            error_message=None,
+            output_chars=len(new_body) if new_body else None,
+            created_at=attempt_ts,
+        )
+
+        if attempted % progress_interval == 0 or attempted == total_rows:
+            method_summary = ", ".join(f"{k}={v}" for k, v in sorted(method_counts.items()))
+            logger.info(
+                "Enrich progress attempted=%d/%d enriched=%d queued=%d unchanged=%d misses=%d methods=%s",
+                attempted, total_rows, enriched, len(updates), unchanged, misses, method_summary,
+            )
+
+    if updates:
+        conn.executemany(
+            """
+            UPDATE articles
+            SET body = ?, body_norm = ?, body_hash = ?, simhash = ?, extraction_method = ?
+            WHERE article_id = ?
+            """,
+            updates,
+        )
+    conn.commit()
+
+    updated = len(updates)
+    method_summary = ", ".join(f"{k}={v}" for k, v in sorted(method_counts.items()))
+    logger.info(
+        "Enrich finished attempted=%d enriched=%d updated=%d unchanged=%d misses=%d methods=%s",
+        attempted, enriched, updated, unchanged, misses, method_summary,
+    )
+
+    return {
+        "attempted": attempted,
+        "enriched": enriched,
+        "updated": updated,
+        "unchanged": unchanged,
+        "misses": misses,
+        "markdown_new_used": markdown_new_used,
+        "markdown_new_rate_limited": markdown_new_rate_limited,
+        "stopped_early": stopped_early,
+        "method_counts": dict(method_counts),
+        "defuddle_enabled": DEFUDDLE_ENABLED,
+    }
+
+
+def _create_stage_run(conn, run_id: str, stage_name: str) -> int:
+    started_at = utc_now_iso()
+    stage_run_id = run_repo.create_stage_run(conn, run_id, stage_name, started_at)
+    conn.commit()
+    return stage_run_id
+
+
+def _complete_stage_run(conn, stage_run_id: int, status: str, metrics: dict) -> None:
+    run_repo.complete_stage_run(conn, stage_run_id, utc_now_iso(), status, metrics)
+    conn.commit()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Enrich articles with body content extraction")
+    parser.add_argument("--limit", type=int, default=None, help="Max articles to process (default: 500)")
+    parser.add_argument("--all", action="store_true", help="Process all matching articles (ignores --limit)")
+    parser.add_argument("--only-missing", action="store_true", default=True, help="Only process articles with empty/short bodies")
+    parser.add_argument("--no-only-missing", action="store_false", dest="only_missing", help="Process all articles regardless of body length")
+    parser.add_argument("--only-dirty", action="store_true", help="Only process articles with likely dirty bodies")
+    parser.add_argument("--skip-enriched", action="store_true", default=True, help="Skip articles already enriched")
+    parser.add_argument("--no-skip-enriched", action="store_false", dest="skip_enriched", help="Process articles even if already enriched")
+    parser.add_argument("--max-markdown-new", type=int, default=100, help="Max markdown.new requests")
+    parser.add_argument("--only-method", type=str, choices=["youtube", "trafilatura", "markdown_new", "compress_new", "jina", "defuddle"], default=None, help="Force specific extraction method only")
+    parser.add_argument("--source-id", type=str, default=None, help="Filter to a specific source")
+    parser.add_argument("--exclude-source", type=str, default=None, help="Exclude source(s), comma-separated")
+    args = parser.parse_args()
+
+    return run_enrich_pipeline(
+        limit=None if args.all else args.limit,
+        only_missing=args.only_missing,
+        only_dirty=args.only_dirty,
+        skip_enriched=args.skip_enriched,
+        max_markdown_new=args.max_markdown_new,
+        only_method=args.only_method,
+        source_id=args.source_id,
+        exclude_source=args.exclude_source,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/jobs/fetch_pipeline.py
+++ b/app/jobs/fetch_pipeline.py
@@ -1,0 +1,189 @@
+"""Fetch-only pipeline: ingest RSS/Atom feeds and store articles without enrichment.
+
+This pipeline fetches RSS feeds, parses entries, and inserts articles into the
+database using only the RSS summary as the body. No enrichment (trafilatura,
+jina, defuddle, markdown.new, etc.) is performed.
+
+Triggered separately from enrich and classify pipelines so that:
+- Feed ingestion stays fast and isolated from slow enrichment calls.
+- Source health checks are not delayed by enrichment failures/rate limits.
+- Each pipeline can be tuned independently.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+import traceback
+import uuid
+from typing import Any
+
+from app.config import load_sources
+from app.db import get_connection, init_db
+from app.incidents import GitHubIssueClient, sync_incident_open_or_update, sync_incident_resolve
+from app.jobs import stages_ingest
+from app.jobs.pipeline import (
+    DEFUDDLE_ENABLED,
+    REQUEST_TIMEOUT_SECONDS,
+    SETTINGS,
+    SLOW_SOURCE_LATENCY_MS,
+    SOURCE_AUTO_DISABLE_COOLDOWN_HOURS,
+    SOURCE_FAIL_THRESHOLD,
+    SOURCE_TIMEOUTS_SECONDS,
+    canonicalize_url,
+    get_source_timeout_seconds,
+    iso,
+    log_stage_summary,
+    migrate_source_ids,
+    normalize_text,
+    parse_date,
+    parse_date_inferred,
+    reset_markdown_new_circuit_breaker,
+    sha1_hexdigest,
+    should_auto_disable_source,
+    simhash64,
+    source_is_in_cooldown,
+    upsert_sources,
+    utc_now_iso,
+)
+from app.logging_helpers import log_stage_summary
+from app.models import ExtractionMethod
+from app.repos import run_repo
+
+logger = logging.getLogger("news.pipeline")
+
+
+def _noop_enrich(
+    url: str, source_id: str, title: str, body: str
+) -> tuple[str, str, list[dict]]:
+    """No-op enrichment: return the RSS body as-is with method='rss'."""
+    return body, ExtractionMethod.RSS.value, []
+
+
+def run_fetch_pipeline() -> int:
+    reset_markdown_new_circuit_breaker()
+    conn = get_connection()
+    init_db(conn)
+    migrate_source_ids(conn)
+    sources = load_sources()
+
+    requested_source = (os.getenv("PIPELINE_SOURCE_ID") or "").strip()
+    if requested_source and requested_source.lower() != "all":
+        sources = [s for s in sources if s.source_id == requested_source]
+        if not sources:
+            logger.warning(
+                "PIPELINE_SOURCE_ID=%s did not match any configured source",
+                requested_source,
+            )
+
+    exclude_source = (os.getenv("PIPELINE_EXCLUDE_SOURCE") or "").strip()
+    if exclude_source:
+        exclude_ids = {s.strip() for s in exclude_source.split(",") if s.strip()}
+        before = len(sources)
+        sources = [s for s in sources if s.source_id not in exclude_ids]
+        logger.info(
+            "PIPELINE_EXCLUDE_SOURCE=%s excluded %d sources",
+            exclude_source,
+            before - len(sources),
+        )
+
+    upsert_sources(conn, sources)
+
+    run_id = uuid.uuid4().hex[:12]
+    run_repo.create_pipeline_run(conn, run_id, utc_now_iso(), run_type="fetch")
+    conn.commit()
+
+    issue_client = GitHubIssueClient()
+    pipeline_metrics: dict[str, Any] = {"run_id": run_id}
+    github_run_id = os.getenv("GITHUB_RUN_ID")
+    github_repo = os.getenv("GITHUB_REPOSITORY")
+    if github_run_id and github_repo:
+        pipeline_metrics["github_run_id"] = github_run_id
+        pipeline_metrics["github_run_url"] = (
+            f"https://github.com/{github_repo}/actions/runs/{github_run_id}"
+        )
+
+    stage_run_id = _create_stage_run(conn, run_id, "fetch")
+    started = time.time()
+    err = None
+    try:
+        metrics = stages_ingest.ingest_stage(
+            conn,
+            run_id,
+            sources,
+            issue_client,
+            defuddle_enabled=DEFUDDLE_ENABLED,
+            source_fail_threshold=SOURCE_FAIL_THRESHOLD,
+            source_auto_disable_cooldown_hours=SOURCE_AUTO_DISABLE_COOLDOWN_HOURS,
+            source_is_in_cooldown=source_is_in_cooldown,
+            should_auto_disable_source=should_auto_disable_source,
+            utc_now_iso=utc_now_iso,
+            iso=iso,
+            parse_date=parse_date,
+            parse_date_inferred=parse_date_inferred,
+            canonicalize_url=canonicalize_url,
+            normalize_text=normalize_text,
+            sha1_hexdigest=sha1_hexdigest,
+            simhash64=simhash64,
+            enrich_article_content=_noop_enrich,
+            get_source_timeout_seconds=get_source_timeout_seconds,
+            slow_source_latency_ms=SLOW_SOURCE_LATENCY_MS,
+        )
+        metrics["duration_ms"] = round((time.time() - started) * 1000, 2)
+        _complete_stage_run(conn, stage_run_id, "success", metrics)
+
+        pipeline_metrics["fetch"] = metrics
+        run_repo.complete_pipeline_run(conn, run_id, utc_now_iso(), pipeline_metrics)
+        conn.commit()
+
+        log_stage_summary(logger, stage_name="fetch", status="success", metrics=metrics, run_id=run_id)
+        logger.info("Fetch pipeline succeeded run_id=%s", run_id)
+
+        sync_incident_resolve(
+            conn,
+            incident_key="pipeline:fetch",
+            run_id=run_id,
+            resolution_message="Fetch pipeline completed successfully.",
+            client=issue_client,
+        )
+        conn.commit()
+        return 0
+
+    except Exception as exc:
+        err = exc
+        logger.exception("Fetch pipeline failed run_id=%s error=%s", run_id, exc)
+        conn.rollback()
+        traceback_text = traceback.format_exc(limit=5)
+        run_repo.fail_pipeline_run(conn, run_id, utc_now_iso(), str(exc), pipeline_metrics)
+        conn.commit()
+        sync_incident_open_or_update(
+            conn,
+            IncidentSignal(
+                key="pipeline:fetch",
+                kind="pipeline-stage",
+                target_id="fetch",
+                message=f"Fetch pipeline failed in run {run_id}: {exc}\n\n{traceback_text}",
+                severity="sev2",
+            ),
+            run_id=run_id,
+            client=issue_client,
+        )
+        conn.commit()
+        return 1
+
+
+def _create_stage_run(conn, run_id: str, stage_name: str) -> int:
+    started_at = utc_now_iso()
+    stage_run_id = run_repo.create_stage_run(conn, run_id, stage_name, started_at)
+    conn.commit()
+    return stage_run_id
+
+
+def _complete_stage_run(conn, stage_run_id: int, status: str, metrics: dict) -> None:
+    run_repo.complete_stage_run(conn, stage_run_id, utc_now_iso(), status, metrics)
+    conn.commit()
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_fetch_pipeline())

--- a/app/jobs/fetch_pipeline.py
+++ b/app/jobs/fetch_pipeline.py
@@ -12,17 +12,19 @@ Triggered separately from enrich and classify pipelines so that:
 
 from __future__ import annotations
 
+import argparse
 import logging
 import os
 import time
 import traceback
 import uuid
+from pathlib import Path
 from typing import Any
 
 from app.config import load_sources
 from app.db import get_connection, init_db
 from app.incidents import GitHubIssueClient, sync_incident_open_or_update, sync_incident_resolve
-from app.jobs import stages_ingest
+from app.jobs import stages_ingest, stages_export
 from app.jobs.pipeline import (
     DEFUDDLE_ENABLED,
     REQUEST_TIMEOUT_SECONDS,
@@ -31,7 +33,18 @@ from app.jobs.pipeline import (
     SOURCE_AUTO_DISABLE_COOLDOWN_HOURS,
     SOURCE_FAIL_THRESHOLD,
     SOURCE_TIMEOUTS_SECONDS,
+    STATUS_DIR,
+    ARTICLES_EXPORT_LIMIT,
+    EVENTS_EXPORT_LIMIT,
+    build_articles,
+    build_events,
+    build_incidents,
+    build_runs,
+    build_sources,
+    build_summary,
     canonicalize_url,
+    classify_event,
+    extract_tags,
     get_source_timeout_seconds,
     iso,
     log_stage_summary,
@@ -61,7 +74,23 @@ def _noop_enrich(
     return body, ExtractionMethod.RSS.value, []
 
 
-def run_fetch_pipeline() -> int:
+def run_export(conn) -> dict[str, Any]:
+    logger.info("Running lightweight export for feed dashboard")
+    metrics = stages_export.export_status(
+        conn,
+        status_dir=STATUS_DIR,
+        build_summary_fn=lambda c: build_summary(c),
+        build_sources_fn=lambda c: build_sources(c),
+        build_runs_fn=lambda c: build_runs(c),
+        build_incidents_fn=lambda c: build_incidents(c),
+        build_events_fn=lambda c: build_events(c),
+        build_articles_fn=lambda c: build_articles(c),
+    )
+    logger.info("Export completed: %s", metrics)
+    return metrics
+
+
+def run_fetch_pipeline(export: bool = False) -> int:
     reset_markdown_new_circuit_breaker()
     conn = get_connection()
     init_db(conn)
@@ -140,6 +169,12 @@ def run_fetch_pipeline() -> int:
         log_stage_summary(logger, stage_name="fetch", status="success", metrics=metrics, run_id=run_id)
         logger.info("Fetch pipeline succeeded run_id=%s", run_id)
 
+        if export:
+            export_metrics = run_export(conn)
+            pipeline_metrics["export"] = export_metrics
+            run_repo.complete_pipeline_run(conn, run_id, utc_now_iso(), pipeline_metrics)
+            conn.commit()
+
         sync_incident_resolve(
             conn,
             incident_key="pipeline:fetch",
@@ -185,5 +220,17 @@ def _complete_stage_run(conn, stage_run_id: int, status: str, metrics: dict) -> 
     conn.commit()
 
 
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Fetch-only pipeline: ingest RSS feeds")
+    parser.add_argument(
+        "--export",
+        action="store_true",
+        default=False,
+        help="Export status files after fetch (enables feed dashboard without classify pipeline)",
+    )
+    args = parser.parse_args()
+    return run_fetch_pipeline(export=args.export)
+
+
 if __name__ == "__main__":
-    raise SystemExit(run_fetch_pipeline())
+    raise SystemExit(main())

--- a/app/jobs/pipeline.py
+++ b/app/jobs/pipeline.py
@@ -1023,6 +1023,104 @@ def build_articles(conn: sqlite3.Connection) -> list[dict[str, Any]]:
     )
 
 
+def fetch_stage(
+    conn: sqlite3.Connection,
+    run_id: str,
+    sources: list[SourceConfig],
+    issue_client: GitHubIssueClient,
+) -> StageResult:
+    from app.jobs import stages_ingest
+
+    def _noop_enrich(url, source_id, title, body):
+        return body, ExtractionMethod.RSS.value, []
+
+    metrics = stages_ingest.ingest_stage(
+        conn,
+        run_id,
+        sources,
+        issue_client,
+        defuddle_enabled=DEFUDDLE_ENABLED,
+        source_fail_threshold=SOURCE_FAIL_THRESHOLD,
+        source_auto_disable_cooldown_hours=SOURCE_AUTO_DISABLE_COOLDOWN_HOURS,
+        source_is_in_cooldown=source_is_in_cooldown,
+        should_auto_disable_source=should_auto_disable_source,
+        utc_now_iso=utc_now_iso,
+        iso=iso,
+        parse_date=parse_date,
+        parse_date_inferred=parse_date_inferred,
+        canonicalize_url=canonicalize_url,
+        normalize_text=normalize_text,
+        sha1_hexdigest=sha1_hexdigest,
+        simhash64=simhash64,
+        enrich_article_content=_noop_enrich,
+        get_source_timeout_seconds=get_source_timeout_seconds,
+        slow_source_latency_ms=SLOW_SOURCE_LATENCY_MS,
+    )
+    return StageResult(status="success", metrics=metrics)
+
+
+def enrich_stage(conn: sqlite3.Connection, run_id: str) -> StageResult:
+    from app.jobs import enrich_pipeline as enrich_mod
+
+    limit = os.getenv("ENRICH_LIMIT")
+    only_method = os.getenv("ENRICH_ONLY_METHOD") or None
+
+    try:
+        result = enrich_mod._enrich_articles(
+            conn,
+            run_id,
+            limit=int(limit) if limit else 500,
+            only_missing=True,
+            only_dirty=False,
+            skip_enriched=True,
+            max_markdown_new=100,
+            only_method=only_method,
+            source_id=None,
+            exclude_source=None,
+        )
+        return StageResult(status="success", metrics=result)
+    except Exception as e:
+        return StageResult(status="failed", metrics={}, error_message=str(e))
+
+
+def classify_stage(conn: sqlite3.Connection, run_id: str) -> StageResult:
+    from app.jobs import stages_cluster, stages_export
+
+    cluster_metrics = stages_cluster.cluster_stage(
+        conn,
+        parse_date=parse_date,
+        iso=iso,
+        pair_similarity=pair_similarity,
+        sha1_hexdigest=sha1_hexdigest,
+        similarity_threshold=SIMILARITY_THRESHOLD,
+        cluster_window_hours=CLUSTER_WINDOW_HOURS,
+        cluster_lookback_days=CLUSTER_LOOKBACK_DAYS,
+    )
+
+    categorize_metrics = stages_cluster.categorize_stage(
+        conn,
+        classify_event=classify_event,
+    )
+
+    export_metrics = stages_export.export_status(
+        conn,
+        status_dir=STATUS_DIR,
+        build_summary_fn=build_summary,
+        build_sources_fn=build_sources,
+        build_runs_fn=build_runs,
+        build_incidents_fn=build_incidents,
+        build_events_fn=build_events,
+        build_articles_fn=build_articles,
+    )
+
+    combined_metrics = {
+        "cluster": cluster_metrics,
+        "categorize": categorize_metrics,
+        "export": export_metrics,
+    }
+    return StageResult(status="success", metrics=combined_metrics)
+
+
 def run_pipeline() -> int:
     reset_markdown_new_circuit_breaker()
     conn = get_connection()
@@ -1064,11 +1162,11 @@ def run_pipeline() -> int:
         pipeline_metrics["github_run_url"] = (
             f"https://github.com/{github_repo}/actions/runs/{github_run_id}"
         )
+
     stages = [
-        ("ingest", lambda: ingest_stage(conn, run_id, sources, issue_client)),
-        ("cluster", lambda: cluster_stage(conn)),
-        ("categorize", lambda: categorize_stage(conn)),
-        ("export", lambda: export_status(conn)),
+        ("fetch", lambda: fetch_stage(conn, run_id, sources, issue_client)),
+        ("enrich", lambda: enrich_stage(conn, run_id)),
+        ("classify", lambda: classify_stage(conn, run_id)),
     ]
 
     logger.info(


### PR DESCRIPTION
## Separate Pipelines Rationale

### Why split the pipeline?

1. **Independent scaling** - Each pipeline can run on different schedules
   - `fetch` - runs every 30 min (fast, just RSS ingestion)
   - `enrich` - runs on demand (slow, API calls to extract content)
   - `classify` - runs when ready (ML clustering + categorization)

2. **Failure isolation** - Enrichment failures don't block feed updates

3. **Flexibility** - Can run fetch+export without classify while ML is being finalized

### Current pipeline stages:

| Pipeline | Stages | What it does |
|----------|--------|--------------|
| `fetch` | ingest | Fetch RSS feeds, store in DB |
| `enrich` | enrich | Extract full content (trafilatura, jina, defuddle) |
| `classify` | cluster, categorize, export | Group articles into events, assign topics, write JSON |

### New `--export` flag

Added to `fetch` and `enrich` pipelines:
- `fetch --export` - writes status files after ingestion
- `enrich --export` - writes status files after enrichment
- Topics use source default_category or rule-based classification (no ML needed)

This allows feed to stay updated without running the full classify pipeline.

### Future improvements possible:
- Add cluster stage to fetch/enrich export for deduplicated events
- Run classify (categorize only) later when ML is ready
- Re-run classify to improve topics while keeping fetch/enrich fast